### PR TITLE
Update fmt_Metasequoia_mqo.py to display quads correctly

### DIFF
--- a/LegacyRepo/finale00/fmt_Metasequoia_mqo.py
+++ b/LegacyRepo/finale00/fmt_Metasequoia_mqo.py
@@ -112,8 +112,11 @@ class SanaeParser(object):
             
             if uvBuff:
                 rapi.rpgBindUV1Buffer(uvBuff, noesis.RPGEODATA_FLOAT, 8)
-            
-            rapi.rpgCommitTriangles(idxBuff, noesis.RPGEODATA_UINT, numIdx, noesis.RPGEO_QUAD, 1)        
+            # RPGEO_QUAD, //ABC_DCB
+            # RPGEO_QUAD_ABC_BCD,
+            # RPGEO_QUAD_ABC_ACD,
+            # RPGEO_QUAD_ABC_DCA 
+            rapi.rpgCommitTriangles(idxBuff, noesis.RPGEODATA_UINT, numIdx, noesis.RPGEO_QUAD_ABC_ACD, 1)        
         
         
     def parse_materials(self, numMat):


### PR DESCRIPTION
Quads now displayed correctly. Wrong RPGEO_QUAD constant was used.